### PR TITLE
webpack issue

### DIFF
--- a/src/bitly.js
+++ b/src/bitly.js
@@ -2,7 +2,7 @@
 
 const url = require('url');
 const isUri = require('valid-url').isUri;
-const fetch = require('node-fetch');
+const fetch = require('node-fetch').default;
 
 
 class Bitly {


### PR DESCRIPTION
Because serverless uses webpack to package scripts for Lambda (or any other FASS service), when using bitly4api the function errors out: `error: TypeError: fetch is not a function`.

Applied this fix here https://github.com/node-fetch/node-fetch/issues/450#issuecomment-387045223